### PR TITLE
Fix prefix parsing and log message

### DIFF
--- a/src/CommandRouter.ts
+++ b/src/CommandRouter.ts
@@ -212,8 +212,10 @@ export default class CommandRouter {
       return;
     }
 
+    const prefix = await this.getPrefix(msg);
+
     const [commandName, subCommandName, args] = await this.breakDownMessage(
-      msg.content.slice(1)
+      msg.content.slice(prefix.length)
     );
 
     let rootCommand = this.commands.get(commandName);

--- a/src/controllers/SnippetController.ts
+++ b/src/controllers/SnippetController.ts
@@ -100,8 +100,11 @@ export class SnippetController {
         return;
       }
 
-      // Extract snippet name (removing the `-` prefix)
-      const snippetName = message.content.slice(1).trim().split(/\s+/)[0];
+      // Extract snippet name (removing the configured prefix)
+      const snippetName = message.content
+        .slice(config.prefix.length)
+        .trim()
+        .split(/\s+/)[0];
 
       if (!snippetName) {
         return;

--- a/src/services/SnippetService.ts
+++ b/src/services/SnippetService.ts
@@ -45,7 +45,7 @@ export class SnippetService {
    * @param names Array of reserved names
    */
   setReservedNames(names: Set<string>): void {
-    this.logger.debug({ names }, `Setting reserved names}`);
+    this.logger.debug({ names }, "Setting reserved names");
 
     this.reservedNames = names;
   }


### PR DESCRIPTION
## Summary
- respect runtime-configured prefix length in command parsing
- handle custom prefixes in SnippetController when extracting snippet names
- clean up SnippetService debug log message

## Testing
- `bun test` *(fails: Cannot find package 'discord.js')*

------
https://chatgpt.com/codex/tasks/task_e_6843b1e89660832793e32ec1dc652693